### PR TITLE
Add language-specific exercise support and dynamic course-to-exercise linking

### DIFF
--- a/app/routes/exercise.py
+++ b/app/routes/exercise.py
@@ -8,7 +8,9 @@ exercise_bp = Blueprint('exercise_bp', __name__, url_prefix='/exercise')
 
 @exercise_bp.route('/exercises')
 def exercises():
-    return render_template('exercises.html')
+    lang = request.args.get('lang', 'spanish') 
+    return render_template('exercises.html', lang=lang)
+
 
 @exercise_bp.route('/submit', methods=['POST'])
 @login_required

--- a/app/static/css/courses.css
+++ b/app/static/css/courses.css
@@ -166,7 +166,7 @@
     background-color: #27ae60;
 }
 
-.course-card .join-button {
+/* .course-card .join-button {
     background-color: var(--secondary-color);
     color: var(--white);
     border: none;
@@ -177,7 +177,7 @@
     transition: background-color var(--transition-speed) ease, transform var(--transition-speed) ease;
     box-shadow: 0 2px 4px rgba(0, 64, 255, 0.2);
     width: 100%;
-}
+} */
 
 .course-card .join-button:hover {
     background-color: var(--secondary-hover);
@@ -233,3 +233,30 @@
         font-size: 1rem;
     }
 }
+
+/* Join  */
+.join-row {
+    display: flex;
+    justify-content: space-between; 
+    align-items: center;
+    margin-top: 10px;
+}
+
+.lang-label {
+    font-weight: 500;
+    color: #333;
+    font-size: 14px;
+}
+
+.join-button {
+    padding: 6px 14px;
+    font-size: 14px;
+    background-color: #007bff;
+    color: white;
+    border: none;
+    border-radius: 6px;
+    text-decoration: none;
+    cursor: pointer;
+    display: inline-block;
+}
+

--- a/app/static/js/courses.js
+++ b/app/static/js/courses.js
@@ -46,7 +46,10 @@ document.addEventListener('DOMContentLoaded', () => {
                     <span class="purpose">Purpose: ${course.purpose.charAt(0).toUpperCase() + course.purpose.slice(1)}</span>
                     <span class="level">Level: ${course.level.toUpperCase()}</span>
                 </div>
-                <a href="/exercise/exercises" class="join-button">Join</a>
+                <div class="join-row">
+                    <span class="lang-label">${course.language.charAt(0).toUpperCase() + course.language.slice(1)}</span>
+                    <a href="/exercise/exercises?lang=${course.language}" class="join-button">Join</a>
+                </div>
             `;
             courseListSection.appendChild(courseCard);
         });

--- a/app/static/js/courses.js
+++ b/app/static/js/courses.js
@@ -46,7 +46,7 @@ document.addEventListener('DOMContentLoaded', () => {
                     <span class="purpose">Purpose: ${course.purpose.charAt(0).toUpperCase() + course.purpose.slice(1)}</span>
                     <span class="level">Level: ${course.level.toUpperCase()}</span>
                 </div>
-                <button class="join-button">Join</button>
+                <a href="/exercise/exercises" class="join-button">Join</a>
             `;
             courseListSection.appendChild(courseCard);
         });

--- a/app/static/js/exercises.js
+++ b/app/static/js/exercises.js
@@ -1,10 +1,68 @@
-const questions = [
-    { text: 'Translate: "Hola, ¿cómo estás?"', options: ['Hello, how are you?', 'Goodbye, see you!', 'I am fine, thanks!'], correct: 0 },
-    { text: 'Translate: "Gracias"', options: ['Thank you', 'Please', 'Goodbye'], correct: 0 },
-    { text: 'Translate: "Buenos días"', options: ['Good morning', 'Good night', 'Good afternoon'], correct: 0 },
-    { text: 'Translate: "Lo siento"', options: ['I\'m sorry', 'I love you', 'Excuse me'], correct: 0 },
-    { text: 'Translate: "Adios"', options: ['Hello', 'Thank you', 'Goodbye'], correct: 2 }
+// Get 'lang' parameter from URL or default to 'spanish'
+const urlParams = new URLSearchParams(window.location.search);
+const lang = urlParams.get('lang') || 'spanish';
+
+// Shared answer options for all languages
+const baseOptions = [
+    ['Hello, how are you?', 'Goodbye, see you!', 'I am fine, thanks!'],
+    ['Thank you', 'Please', 'Goodbye'],
+    ['Good morning', 'Good night', 'Good afternoon'],
+    ["I'm sorry", 'I love you', 'Excuse me'],
+    ['Hello', 'Thank you', 'Goodbye']
 ];
+
+// Correct answer index for each question (0-based)
+const correctAnswerIndices = [0, 0, 0, 0, 2]; // Correct option indexes for each question
+
+// Multilingual versions of each question (same structure, different language)
+const questionTexts = {
+    spanish: [
+        'Translate: "Hola, ¿cómo estás?"',
+        'Translate: "Gracias"',
+        'Translate: "Buenos días"',
+        'Translate: "Lo siento"',
+        'Translate: "Adiós"'
+    ],
+    french: [
+        'Translate: "Bonjour, comment ça va ?" ',
+        'Translate: "Merci"',
+        'Translate: "Bonjour"',
+        'Translate: "Je suis désolé"',
+        'Translate: "Au revoir"'
+    ],
+    japanese: [
+        'Translate: "こんにちは、お元気ですか？"',
+        'Translate: "ありがとう"',
+        'Translate: "おはようございます"',
+        'Translate: "ごめんなさい"',
+        'Translate: "さようなら"'
+    ],
+    english: [
+        'Translate: "Hello, how are you?"',
+        'Translate: "Thank you"',
+        'Translate: "Good morning"',
+        'Translate: "I\'m sorry"',
+        'Translate: "Goodbye"'
+    ],
+    chinese: [
+        'Translate: "你好，最近怎么样？"',
+        'Translate: "谢谢"',
+        'Translate: "早上好"',
+        'Translate: "对不起"',
+        'Translate: "再见"'
+    ]
+};
+
+// Select question set for the current language or fallback to Spanish
+const langQuestions = questionTexts[lang] || questionTexts['spanish'];
+
+// Combine question text, options, and correct answer index
+const questions = langQuestions.map((qText, index) => ({
+    text: qText,
+    options: baseOptions[index],
+    correct: correctAnswerIndices[index]
+}));
+
 
 let currentQuestion = 0;
 let correctAnswers = 0;

--- a/app/templates/exercises.html
+++ b/app/templates/exercises.html
@@ -19,7 +19,16 @@
     </nav>
 </header>
 <main>
-    <h1>Spanish Exercise - Lesson 3</h1>
+    <h1>{{ lang.capitalize() }} Exercise</h1>
+    {% if lang == 'spanish' %}
+        <p class="tip">Tip: Use words like "Hola", "Gracias", "Adiós"</p>
+    {% elif lang == 'french' %}
+        <p class="tip">Tip: Use words like "Bonjour", "Merci", "Au revoir"</p>
+    {% elif lang == 'japanese' %}
+        <p class="tip">ヒント：「こんにちは」「ありがとう」など基本の単語を覚えましょう。</p>
+    {% else %}
+        <p class="tip">General language tips will go here.</p>
+    {% endif %}
     <div class="progress-tracker">
         <span id="question-counter">Question 1 of 5</span>
         <div class="progress-bar">


### PR DESCRIPTION
## Summary

This pull request implements dynamic exercise content switching based on course language selection. Each course card's Join button now links to the appropriate language-specific exercise page.

## Features

- 🌐 Language-specific question prompts are shown for:
  - Spanish (default)
  - French
  - Japanese
  - English
  - Chinese (newly added)
- ✏️ All exercises share the same answer options and logic
- 📌 Course cards now display language labels next to the Join button
- 🧭 Join button links to `/exercise/exercises?lang={language}`
- 🛑 Courses without supported exercises can be easily extended or disabled

## Technical Details

- `lang` is parsed from the URL and used to load translated question prompts
- Default fallback is `spanish` if no valid `lang` is provided
- Frontend and backend updated:
  - `courses.js` – dynamic links + language labels
  - `exercises.js` – question set switching
  - `exercise.py` – passes `lang` to the template
  - `exercises.html` – uses `lang` to customize display

## Linked Issue

Closes #51 
